### PR TITLE
added additional logic to handle blank fields in CSVs

### DIFF
--- a/macros/plugins/snowflake/create_external_table.sql
+++ b/macros/plugins/snowflake/create_external_table.sql
@@ -18,7 +18,7 @@
             {%- set column_quoted = adapter.quote(column.name) if column.quote else column.name %}
             {%- set col_expression -%}
                 {%- set col_id = 'value:c' ~ loop.index if is_csv else 'value:' ~ column.name -%}
-                (case when is_null_value({{col_id}}) or lower({{col_id}}) = 'null' then null else {{col_id}} end)
+                (case when is_null_value({{col_id}}) or lower({{col_id}}) = 'null' or {{col_id}} = '' then null else {{col_id}} end)
             {%- endset %}
             {{column_quoted}} {{column.data_type}} as ({{col_expression}}::{{column.data_type}})
             {{- ',' if not loop.last -}}


### PR DESCRIPTION
## Description & motivation
<!---
Added additional logic for creating Snowflake External Tables as currently blank fields in CSV files in S3 are being treated as varchar instead of null, which is leading to "failed to cast from variant" errors in Snowflake.
-->

## Checklist
- [X] I have verified that these changes work locally
- [NA] I have updated the README.md (if applicable)
- [NA] I have added an integration test for my fix/feature (if applicable)
